### PR TITLE
#1 parent query selector

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,4 +1,2 @@
-import { Component } from './component';
-import { WrappedComponent } from './integration';
-export declare const TestComponent: typeof Component;
-export declare const IntegrationComponent: typeof WrappedComponent;
+export { Component as TestComponent } from './component';
+export { WrappedComponent as IntegrationComponent } from './integration';

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var component_1 = require("./component");
-var integration_1 = require("./integration");
 exports.TestComponent = component_1.Component;
+var integration_1 = require("./integration");
 exports.IntegrationComponent = integration_1.WrappedComponent;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nology/angular-test-simplifier",
-  "version": "0.0.11",
+  "version": "0.0.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/base.ts
+++ b/src/base.ts
@@ -11,8 +11,6 @@ export class ConfiguredTestComp<CustomComponent> {
   public fixture: ComponentFixture<any>;
   public instance: CustomComponent;
   public element;
-  // declarations: any[];
-  // imports: any[];
   protected config: TestModuleMetadata = {
     declarations: [],
     imports: [],

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -33,4 +33,8 @@ export class WrappedComponent<CustomComponent, WrapperComponent> extends Configu
     });
     this.updateFixture();
   }
+
+  public querySelector(element: string) {
+    return this.parentElement.querySelector(element);
+  }
 }


### PR DESCRIPTION
Created polymorphic version of querySelector method in the integration component so it runs against parentElement and not element. When testing integrating components we need to look in the parent wrapper element to find the desired element/directive.

Original usage: integratedComp.parentElement.querySelector('xyz');
New usage: integratedComp.querySelector('xyz');

I have tested this against existing working bookworm tests.

N.B. This will help/may remove the next ticket of integratedComp not working with triggerEvent method